### PR TITLE
Make sure that no LF to CR/LF translation happens on the attachment.

### DIFF
--- a/erroraction.cmd
+++ b/erroraction.cmd
@@ -116,7 +116,7 @@ GOTO:EOF
 set attachment=
 IF "%COMPRESS_LOGS%"=="yes" (
 	"%PROGRAM_PATH%\bin\gzip" -c "%SMART_LOG_FILE%" > "%SMART_LOG_FILE%.gz"
-	set attachment=-attach "%SMART_LOG_FILE%.gz"
+	set attachment=-attach "%SMART_LOG_FILE%.gz,application/x-gzip,a"
 ) ELSE (
 	set attachment=-attach "%SMART_LOG_FILE%"
 )

--- a/erroraction.cmd
+++ b/erroraction.cmd
@@ -116,7 +116,7 @@ GOTO:EOF
 set attachment=
 IF "%COMPRESS_LOGS%"=="yes" (
 	"%PROGRAM_PATH%\bin\gzip" -c "%SMART_LOG_FILE%" > "%SMART_LOG_FILE%.gz"
-	set attachment=-attach "%SMART_LOG_FILE%.gz,application/x-gzip,a"
+	set attachment=-attach "%SMART_LOG_FILE%.gz,application/gzip,a"
 ) ELSE (
 	set attachment=-attach "%SMART_LOG_FILE%"
 )


### PR DESCRIPTION
The smart.log.gz attachment in the received email was sometime corrupted. A binary diff with the one being sent showed that there were LF to CR/LF translations in the attachment. This change ensures that the attachment has a binary mime type that does not need LF to CR/LF translations.